### PR TITLE
Added `keystore_file` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,13 @@ Build a signed APK of your Android application
 
 The following inputs are all required
 
-- `keystore`: the keystore file (.jks) as base64. I highly recommand you to generate this with the linux `base64` command, it did not work for me using websites to convert it
+- `keystore_b64` (optional, in alternative to `keystore_file`): the _contents of_ the keystore file (.jks), encoded as base64. (_I highly recommend you to generate this with the linux `base64` command, it did not work for me using websites to convert it._)
+- `keystore_file` (optional, in alternative to `keystore`): the path to the keystore file (.jks). There's no need to encode it as base64.
 - `keystore_password`: the password of the file
 - `key_alias`: the alias of the key
 - `key_password`: the password of the key
+
+If both `keystore_b64` and `keystore_file` are defined, only `keystore_b64` will be used. At least one of them must be defined.
 
 ## Example
 

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ branding:
 
 inputs:
 
-  keystore:
+  keystore_b64:
     description: "The contents of the keystore file, encoded as base64"
     required: false
     
@@ -38,13 +38,13 @@ runs:
       shell: bash
       
     - shell: bash
-      run: echo "${{ inputs.keystore }}" | base64 -d > $GITHUB_WORKSPACE/signing-key.jks
-      if: inputs.keystore
+      run: echo "${{ inputs.keystore_b64 }}" | base64 -d > $GITHUB_WORKSPACE/signing-key.jks
+      if: inputs.keystore_b64
       
     - name: Copy the key file to the signing key file
       run: cp ${{ inputs.keystore_file }} $GITHUB_WORKSPACE/signing-key.jks
       shell: bash
-      if: inputs.keystore_file && !inputs.keystore
+      if: inputs.keystore_file && !inputs.keystore_b64
 
     - run: chmod +x ./gradlew
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -8,8 +8,12 @@ branding:
 inputs:
 
   keystore:
-    description: "Keystore file encoded as base64"
-    required: true
+    description: "The contents of the keystore file, encoded as base64"
+    required: false
+    
+  keystore_file:
+    description: "The path to the .jks keystore file"
+    required: false
     
   keystore_password:
     description: "Keystore file password"
@@ -32,9 +36,15 @@ runs:
 
     - run: sudo apt-get -y install openjdk-11-jdk
       shell: bash
-
-    - run: echo "${{ inputs.keystore }}" | base64 -d > $GITHUB_WORKSPACE/signing-key.jks
+      
+    - shell: bash
+      run: echo "${{ inputs.keystore }}" | base64 -d > $GITHUB_WORKSPACE/signing-key.jks
+      if: inputs.keystore
+      
+    - name: Copy the key file to the signing key file
+      run: cp ${{ inputs.keystore_file }} $GITHUB_WORKSPACE/signing-key.jks
       shell: bash
+      if: inputs.keystore_file && !inputs.keystore
 
     - run: chmod +x ./gradlew
       shell: bash


### PR DESCRIPTION
This PR addresses #1 . It implements two separate optional parameters, `keystore_b64` (replacing `keystore`); and `keystore_file`.